### PR TITLE
Parallelization: Lock Free message queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,3 +58,11 @@ add_custom_target(test
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running MarketClient test..."
     )
+
+# Add custom test target
+add_custom_target(main
+    DEPENDS ${PROJECT_NAME}
+    COMMAND ${PROJECT_NAME}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running main..."
+    )

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,8 @@
 #include "MarketMaker.h"
 #include "Tickers.h"
 #include "Utils.h"
+#include "OrderQueue.h"
+
 #include <iostream>
 #include <thread>
 
@@ -25,16 +27,16 @@ void staticPublisher(Market& m) {
 }
 
 int main(void) {
-    Market m = Market();
+    Market market = Market();
     instrument::ticker ticker1 = TickerNames::BOOGLE;
-    m.addTicker(ticker1);
+    market.addTicker(ticker1);
 
-    MarketServer ms = MarketServer(m);
+    MarketServer ms = MarketServer(market);
     
-    std::thread marketMakerThread(defaultLiquidity, std::ref(m));
+    std::thread marketMakerThread(defaultLiquidity, std::ref(market));
     marketMakerThread.detach();
 
-    std::thread publisherThread(staticPublisher, std::ref(m));
+    std::thread publisherThread(staticPublisher, std::ref(market));
     publisherThread.detach();
 
     ms.runServer();

--- a/src/headers/Market.h
+++ b/src/headers/Market.h
@@ -1,12 +1,15 @@
 #pragma once
 #include"Orderbook.h"
 #include<array>
+#include<thread>
 
 class Market {
 
     private:
-        static const uint16_t marketSize = 500;
-    public:
+        static const uint16_t marketSize = 500;    
+        std::thread executionThread;
+        void processOrdersLoop();
+    public:    
     
         struct books {
             Orderbook<instrument::BidComparator> bids;
@@ -15,8 +18,8 @@ class Market {
 
         std::array<Market::books, marketSize> market;
         
-        bool placeAsk(instrument::ticker ticker,const instrument::Order & order);
-        bool placeBid(instrument::ticker ticker,const instrument::Order & order);
+        void placeAsk(instrument::ticker ticker,const instrument::Order & order);
+        void placeBid(instrument::ticker ticker,const instrument::Order & order);
         uint32_t getPrice(instrument::ticker ticker);
         
         void matchOrder(books& books);

--- a/src/headers/OrderQueue.h
+++ b/src/headers/OrderQueue.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <atomic>
+#include <vector>
+#include <optional>
+#include <iostream>
+
+/**
+ * Lock Free Ring buffer
+ * Since orders are atomic we can have these be the bid and ask priority queues
+ */
+template<typename T>
+class LockFreeOrderQueue {
+    public: 
+        explicit LockFreeOrderQueue(size_t size)
+         : buffer(size), capacity(size), head(0), tail(0) {}
+
+         bool enqueue(const T& order) {
+            size_t curr_tail;
+
+            do {
+                curr_tail = tail.load(std::memory_order_relaxed);
+                size_t next_tail = increment(curr_tail);
+                if (next_tail == head.load(std::memory_order_acquire)) {
+                    //buffer full
+                    return false;
+                }
+            } while (!tail.compare_exchange_weak(curr_tail, increment(curr_tail), std::memory_order_acquire, std::memory_order_relaxed));
+            
+            buffer[curr_tail] = order;
+            return true;
+        }
+
+        std::optional<T> dequeue() {
+            size_t curr_head = head.load(std::memory_order_relaxed);
+
+            if (curr_head == tail.load(std::memory_order_acquire)) {
+                // buffer empty
+                return std::nullopt;
+            }
+
+            T item = buffer[curr_head];
+            head.store(increment(curr_head), std::memory_order_release);
+            return item;
+        }
+
+    private:
+        //fun circles
+        size_t increment(size_t index) const {
+            return (index + 1) % capacity;
+        }
+
+        std::vector<T> buffer;
+        const size_t capacity;
+
+        std::atomic<size_t> head;
+        std::atomic<size_t> tail;
+};

--- a/src/service/MarketServer.h
+++ b/src/service/MarketServer.h
@@ -14,11 +14,11 @@ class MarketServer {
          return m.getPrice(ticker);
     };
 
-    std::function<bool(instrument::ticker, instrument::ExternalOrder)> askOrder = [this](instrument::ticker ticker, instrument::ExternalOrder order){
+    std::function<void(instrument::ticker, instrument::ExternalOrder)> askOrder = [this](instrument::ticker ticker, instrument::ExternalOrder order){
         return m.placeAsk(ticker, instrument::createOrder(order)); 
     };
     
-    std::function<bool(instrument::ticker, instrument::ExternalOrder)> bidOrder = [this](instrument::ticker ticker, instrument::ExternalOrder order){
+    std::function<void(instrument::ticker, instrument::ExternalOrder)> bidOrder = [this](instrument::ticker ticker, instrument::ExternalOrder order){
         return m.placeBid(ticker, instrument::createOrder(order)); 
     };
 

--- a/src/test/MarketClientTest.cc
+++ b/src/test/MarketClientTest.cc
@@ -20,7 +20,7 @@ int main(void) {
     };
 
     instrument::ExternalOrder o3 = {
-        .price = 1500,
+        .price = 500,
         .quantity = 50000,
     };
 
@@ -53,7 +53,7 @@ int main(void) {
 
         //c.call("bidOrder", ticker1, o1);
         //c.call("bidOrder", ticker1, o2);
-        c.call("bidOrder", ticker1, o3);
+        c.call("askOrder", ticker1, o3);
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
         


### PR DESCRIPTION
Implemented a basic lock-free order queue for several pubs and one sub, market runs a separate thread which handles order matching now `placeAsk` and `placeBid` are pretty simplified.